### PR TITLE
Add back-link to original self-assessment book for context

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,7 @@ Examples of types of actions that are prohibited at Linux Foundation meetings an
 
 [how the project operates]: governance/GOVERNANCE.md
 [how to report security-related issues]: governance/SECURITY.md
+
+---
+
+This content evolved from the [CNCF TAG Security Security Assessment book](https://github.com/cncf/tag-security/blob/5fb87f474808e02e7786d7c5548e65ffc1a6e29e/community/assessments/Open_and_Secure.pdf) (now archived).  This project aims to extend that guidance to apply to any open-source project, while preserving the experience and expertise which made the CNCF's security assessment program valuable.


### PR DESCRIPTION
As mentioned by Eddie in a call today; the original source material wasn't obvious, which made it more difficult to understand where things should go next.
