### PR TITLE
Update initial getting started content, add CONTRIBUTING doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,30 @@
+# Contributing to OSPS Assessments
+
+Thank you for your interest in contributing to the Open Source Project Security (OSPS) Assessments project!
+
+## Community Channels
+
+We welcome questions, feedback, and contributions from the community. The best way to engage with the project is through the OpenSSF Slack workspace.
+
+### Join the Conversation
+
+1. **Join OpenSSF Slack**: If you haven't already, join the [OpenSSF Slack workspace](https://openssf.slack.com/). You can request an invitation at [https://slack.openssf.org/](https://slack.openssf.org/).
+
+2. **Find Us on Slack**: Once you're in the workspace, join the **#wg-orbit** channel where the OSPS Assessments community collaborates.
+
+## Ways to Contribute
+
+- **Ask Questions**: Don't hesitate to ask questions in **#wg-orbit** — we're here to help!
+- **Share Feedback**: Let us know how we can improve the assessment guidance and processes.
+- **Propose Changes**: Open an issue or pull request in this repository to suggest improvements.
+- **Participate in Meetings**: Check the [OpenSSF Community Calendar](https://openssf.org/getinvolved/) for SIG meeting times.
+
+## Code of Conduct
+
+All contributors are expected to adhere to the [OpenSSF Code of Conduct](https://openssf.org/community/code-of-conduct/).
+
+## Questions?
+
+If you have any questions or need help getting started, reach out in the **#wg-orbit** channel on [OpenSSF Slack](https://openssf.slack.com/).
+
+We look forward to your contributions!

--- a/guidance/getting-started.md
+++ b/guidance/getting-started.md
@@ -8,7 +8,7 @@
 
 This guidance describes security assessments, including what a security assessment is, how it differs from a security audit, how to perform a security assessment, and how to use a completed assessment.
 
-These contents are heavily informed by the Security Assessment process developed by the CNCF Security Technical Advisory Group and authored by Justin Cappos (STAG Technical Lead). This draws on years of compound experience analyzing and evaluating security products across a wide array of domains. The examples in this text draw from both non-technical anecdotes and a variety of detailed technical examples from Linux Foundation projects in the cloud native space.
+These contents are heavily informed by the Security Assessment process developed by the CNCF Security and Compliance Technical Advisory Group and authored by Justin Cappos (TAG-SC Technical Lead). This draws on years of compound experience analyzing and evaluating security products across a wide array of domains. The examples in this text draw from both non-technical anecdotes and a variety of detailed technical examples, particularly drawn from from Linux Foundation projects in the cloud native space.
 
 It is recommended to follow the guide one step at a time, rather than seeking to read and understand the process in completeness. You will internalize more by attempting the exercises yourself.
 
@@ -22,7 +22,7 @@ Please do a quick read of the knowledge base before working with reviewers. If y
 
 ### You want to learn about threat modeling and software security
 
-Many are helpful to learn about threat modeling and how to assess the security of general projects. Perhaps the least relevant part are the portions of this book that relate to the specifics of Security Assessments. However, those sections can serve as an example of how to implement some of the ideas in the rest of the book in the cloud native space.
+Many sections are helpful to learn about threat modeling and how to assess the security of general projects. Perhaps the least relevant part are the portions of this book that relate to the specifics of Security Assessments. However, those sections can serve as an example of how to implement some of the ideas in the rest of the book.
 
 ### You want to lead or participate in an assessment
 
@@ -36,6 +36,6 @@ You, the consumer of this hard work, need to understand how best to benefit from
 
 ### If you're still not ready to get started
 
-As with many things in security there is often not one “correct answer”, despite there being infinite wrong answers. If you would like to ask questions or help improve this guidance, please don't hesitate to engage through the designated [community channels](./CONTRIBUTING.md).
+As with many things in security there is often not one “correct answer”, despite there being infinite wrong answers. If you would like to ask questions or help improve this guidance, please don't hesitate to engage through the designated [community channels](../CONTRIBUTING.md).
 
 **[> Next up: Security Basics](./background/security-basics.md)**


### PR DESCRIPTION
Removes a few unnecessary CNCF-specific references, cleans up a few bits of prose, and introduces a `CONTRIBUTING.md` that routes people to CNCF slack (since the previous link was dead).
