### PR TITLE
Fix links, reduce CNCF references in templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ In response to a rising demand for standardized security review of open source p
 
 ## Approach
 
-OSPS Assessments may come in one of two types: self-assessment or joint-assessment. This tiered approach is intended to reduce complexity through a "shift left" approach that encourages participation from project maintainers while also reducing overall cost and complexity.   
+OSPS Assessments may come in one of two types: self-assessment or joint-assessment. This tiered approach is intended to reduce complexity through a "shift left" approach that encourages participation from project maintainers while also reducing overall cost and complexity.
 
 ### Getting Started
 
-Visit [the Getting Started guide](./guidance/background/getting-started.md) to determine your first steps, including which of the assessments is right for your situation. In most cases, it is recommended to start at the lowest level, self-assessments, and work up from there.
+Visit [the Getting Started guide](./guidance/getting-started.md) to determine your first steps, including which of the assessments is right for your situation. In most cases, it is recommended to start at the lowest level, self-assessments, and work up from there.
 
 Continue reading below for a rapid overview of each assessment type.
 
@@ -30,8 +30,7 @@ Linux Foundation meetings involve participation by industry competitors, and it 
 
 Examples of types of actions that are prohibited at Linux Foundation meetings and in connection with Linux Foundation activities are described in the Linux Foundation Antitrust Policy available at http://www.linuxfoundation.org/antitrust-policy. If you have questions about these matters, please contact your company counsel, or if you are a member of the Linux Foundation, feel free to contact Andrew Updegrove of the firm of Gesmer Updegrove LLP, which provides legal counsel to the Linux Foundation.
 
-[how the project operates]: governance/GOVERNANCE.md
-[how to report security-related issues]: governance/SECURITY.md
+[how the project operates]: GOVERNANCE.md
 
 ---
 

--- a/guidance/background/response/applying-mitigations.md
+++ b/guidance/background/response/applying-mitigations.md
@@ -9,7 +9,7 @@ To understand why, let’s go back to TrashPanda Bank and think about their secu
 This also helps to explain why it is so important to design security into a system from the start instead of trying to bolt it on afterwards. If you don’t design things well from the start, it is often impractical or even impossible to get the security properties you want later... at least without starting over.
 
 > [!NOTE]
-> From Graphs to Guards, Commentary by Marco De Benedictis
+> **From Graphs to Guards**, Commentary by Marco De Benedictis
 >
 > Attack Graphs capture the defenders’ mindset and working process, and so are time-consuming and require significant effort to generate to ensure correctness and the completeness of the paths that an attacker could exploit to achieve a potential goal.
 > We can understand if tactical security controls are addressing the most relevant threats by cross-referencing the attack graphs back to the proposed mitigations. This can be practically achieved by overlaying security countermeasures at each individual step, and visually inspecting the branches that aren't properly covered by remediations.

--- a/guidance/background/response/assessments.md
+++ b/guidance/background/response/assessments.md
@@ -10,8 +10,8 @@ Most importantly, if you are designing a security focused system, you need to un
 
 In general, the earlier an assessment is done, the more secure the software will be, and the easier it will be to adapt to any design or other changes that are uncovered by the assessment. So, do your best to start early!
 
-> [!INFO]
-> A Health Check and Path to Enhanced Security, Commentary by Ash Narkar
+> [!NOTE]
+> **A Health Check and Path to Enhanced Security**, Commentary by Ash Narkar
 >
 > The security assessment process really helped the OPA team understand the overall health of the project from a security perspective. The assessment identified areas of the project that could be improved for example better documentation around secure deployment practices, enhancing OPA's toolchain usability to reduce policy authoring related errors. The OPA project benefited from the recommendations and advice provided by the security experts at CNCF's TAG-Security and our on-going relationship with TAG-Security helps us gain insights into the latest security best practices thereby allowing us to continuously improve OPA's security posture.
 

--- a/guidance/background/response/recovery-and-prevention.md
+++ b/guidance/background/response/recovery-and-prevention.md
@@ -19,7 +19,7 @@ Another means to deal with an attack is simply to prevent it from being effectiv
 Note that you need to carefully be able to argue why you protect against a set of attacks. This includes in what scenarios an attacker is prevented from doing an action. Once again, being rigorous and clear about limitations are absolutely key.
 
 > [!IMPORTANT]
-> Aiming for Full Prevention
+> **Aiming for Full Prevention**
 >
 > Some modern systems provide prevention of only certain attacker actions, in only certain scenarios. They may prevent information from being valuable after a certain point of time or from a key from being exfiltrated after a successful attack. (See HSMs, the concept of perfect forward secrecy, and ephemeral keys, as examples.) These properties are certainly nice to have, but ideally you want full prevention as a goal.
 
@@ -30,7 +30,7 @@ A natural next thing to consider once you understand the different means by whic
 To consider another example, let’s say that TrashPanda Bank has a super alarm system that can detect when the view of any sensor is blocked momentarily. Unfortunately, TrashPanda Bank is set near a set of cherry blossom trees and when the blossoms fall, they block the sensors, leading to a ton of false alarms. Suppose that TrashPanda set the alarm to automatically ring the police when it was triggered. After being summoned several times, the police are unlikely to respond to alarms for TrashPanda in the future, leading to the police ignoring an alarm on the vault. So, in this case, the security system’s drawbacks may actually degrade security.
 
 > [!IMPORTANT]
-> Overprotection Sometimes Considered Harmful
+> **Overprotection Sometimes Considered Harmful**
 >
 > While the example above is a bit silly, adding a security mechanism does sometimes degrade security in practice. It used to be thought that changing passwords frequently was an important security practice. It was later shown that this made users choose weaker passwords, reuse passwords more often, and led to companies providing more vulnerable means to recover lost passwords.
 >

--- a/guidance/background/threat-modeling/attack-graphs-technique.md
+++ b/guidance/background/threat-modeling/attack-graphs-technique.md
@@ -33,7 +33,7 @@ graph TD;
 In the next stage, we can see that the goal of learning the combination can be achieved in two ways - finding the written combination and getting the combination from the target (who is an authorized individual possessing the combination to the safe) which can further be done in 4 ways. These represent the OR nodes. Success in any one of these attacks leads to success of the ultimate goal of opening the lock. One attack to retrieve the combination from the target includes eavesdropping, which needs the success of two attacks where the victim states the combination and the attacker listening to the conversation. Failure of either results in an unsuccessful attempt to break the lock open.
 
 > [!NOTE]
-> **Unraveling Attack Graphs, Commentary by Justin Cappos**
+> **Unraveling Attack Graphs**, Commentary by Justin Cappos
 >
 > Attack graphs were really helpful for me when I was first starting to threat model large systems and also are really helpful now when I don’t understand a system well. Today, I often can intuitively go through and enumerate the cases here because I’ve had enough practice. So, I rarely write out an attack graph. (I usually jump straight to attack matrices, which will be described later.)
 >
@@ -44,7 +44,7 @@ One problem with attack graphs is you don’t necessarily know how complete they
 There is a depth of material on attack trees that focuses on adding parameters of different types to them. They can do things like help you reason about what attackers with different skill sets / access / constraints might do in a system or how much an attack might cost an attacker. As you are working through examples, you may find it useful to refer to the following reference: Schneier, B. “Attack Trees.” Schneier on Security, Dr. Dobb's Journal, December 1999, https://www.schneier.com/academic/archives/1999/12/attack_trees.html.
 
 > [!NOTE]
-> Finding Business Value, Commentary from Jack Kelly
+> **Finding Business Value**, Commentary from Jack Kelly
 >
 > For some clients or colleagues Attack Graphs and Trees are a valued deliverable. They are most valued by visual learners and non-technical persons as a tangible representation of what is elaborated on in a Threat Matrix. An Attack Graph helps a reader easily follow from initial breach to the attacker’s goal, and identify which nodes on the graph may be a hotspot either for traversal to other goals, or is used in many possible routes to the same point of impact. This provides a quantifiable justification for the controls used to remediate the threat of attack.
 >

--- a/guidance/background/threat-modeling/dread-technique.md
+++ b/guidance/background/threat-modeling/dread-technique.md
@@ -5,7 +5,7 @@
 The properties of an attack will vary based on the avenue of the attack. Some actions an attacker can only perform once before detection, while others an attacker can do repeatedly. Some require specialized skills, while others can be done by anyone.
 
 > [!NOTE]
-> **From Improbable to Inevitable, Commentary by Justin Cappos**
+> **From Improbable to Inevitable**, Commentary by Justin Cappos
 >
 > It is helpful when thinking about attacks to really think outside the box. One exercise I like to do is to “prove” why an attack couldn’t happen. As I’m reasoning through it, I usually come up with the way in which the attack could occur.
 >

--- a/guidance/background/threat-modeling/goals.md
+++ b/guidance/background/threat-modeling/goals.md
@@ -1,6 +1,6 @@
 # Threat Modeling: Goals
 
-**[< Previous: Actions](./actions)**
+**[< Previous: Actions](./actions.md)**
 
 <!-- TODO: This section is titled "goals," but I don't understand why. It's about bad assumptions -->
 
@@ -38,6 +38,7 @@ In practice, contests like the ones that NIST holds to choose cryptographic algo
 
 After SPECTRE and MELTDOWN, people in the community realized that there are some ways to use rare cache / memory error behaviors to bypass security protections. For example, a program could read memory in the operating system kernel or in another program. A series of defensive code changes now makes these attacks infeasible on modern hardware (as we understand it). The assumption that memory protections work is common not because it is universally thought that memory protection will absolutely hold in all cases, but largely because not having this assumption makes it too challenging to design security systems. It essentially makes it infeasible to do compartmentalization on a single piece of computing hardware and may make it feasible to cause information disclosure from any component on the same physical hardware. As this is currently an area of active research by hardware security researchers and chip makers, the protections and our understanding of the risks in this domain are likely to evolve over time.
 
+> [!IMPORTANT]
 > **Future-proofing While Maintaining Compatibility**
 >
 > Note that today, these assumptions are being relaxed by some modern security systems like TUF. For example, TUF supports multiple cryptographic algorithms and has a built-in way to add and remove cryptographic algorithm support while maintaining security properties. This enables secure migration to new algorithms either proactively, or as the need arises.
@@ -46,7 +47,12 @@ After SPECTRE and MELTDOWN, people in the community realized that there are some
 
 ### An attacker cannot hack a specific component or system
 
-Modern systems tend to have so much code and tend to use so many libraries, that this just isn’t a reasonable expectation. Even a “proven to be secure” microkernel like SeL4 has had security bugs found in it [SeL4 issue #85, SeL4 issue #86, seL4 Version 9.0.0 Release Notes]. It is important to assume code could have bugs, especially large components, and to design your system to have different isolated compartments so that your system’s security will degrade gracefully when components are successfully breached. This assumption seems to be on the way out, but some systems being created today do still use this assumption. You should assume that such compromises are a matter of when, not if [TAG Security Catalog of Supply Chain Compromises].
+Modern systems tend to have so much code and tend to use so many libraries, that this just isn’t a reasonable expectation. Even a “proven to be secure” microkernel like SeL4 has had security bugs found in it [[SeL4 issue #85], [SeL4 issue #86], [seL4 Version 9.0.0 Release Notes]]. It is important to assume code could have bugs, especially large components, and to design your system to have different isolated compartments so that your system’s security will degrade gracefully when components are successfully breached. This assumption seems to be on the way out, but some systems being created today do still use this assumption. You should assume that such compromises are a matter of when, not if [TAG Security Catalog of Supply Chain Compromises].
+
+[SeL4 issue #85]: https://github.com/seL4/seL4/issues/85
+[SeL4 issue #86]: https://github.com/seL4/seL4/issues/86
+[SeL4 Version 9.0.0 Release Notes]: https://docs.sel4.systems/releases/sel4/9.0.0.html
+[TAG Security Catalog of Supply Chain Compromises]: https://contribute.cncf.io/community/tags/security-and-compliance/publications/catalog/
 
 ### A key or other secret will never be leaked, compromised, misgenerated, etc
 
@@ -59,6 +65,8 @@ This assumption isn’t actually a bad one for MFA that does not use SMS. An org
 ### The complexity of parsing code for a complex format is not particularly relevant
 
 This is a common mistake that organizations make, where the code to parse data formats or keys becomes a major liability. The number of X.509 certificate parsing errors alone that have led to security vulnerabilities is astonishing [MatrixSSL: Security Vulnerabilities]. A related problem in this space is that even just getting a format serialized into a consistent format is a more difficult challenge than many developers initially realize. So the complexity of the data communication and storage format should be a major concern, especially for sensitive API calls and components.
+
+[MatrixSSL: Security Vulnerabilities]: https://www.cvedetails.com/vulnerability-list/vendor_id-16019/product_id-35500/
 
 ### Operating system user access control protections like file permissions are an impassable barrier
 
@@ -85,7 +93,7 @@ In much the same way, antivirus software on client machines largely just helps t
 This is patently false, which is one reason why multi-factor authentication is an option or even a requirement for many systems. Strong password guidelines for users are important. Users should also be incentivized to use tools like password managers.
 
 > [!NOTE]
-> A Methodology for Identifying Discrepancies with Respect to Privacy Regulations, Commentary by Ragashree Shekar
+> **A Methodology for Identifying Discrepancies with Respect to Privacy Regulations**, Commentary by Ragashree Shekar
 >
 > In the current landscape, with more and more data generated from each of us through the surplus connected devices we use, it also gives an opportunity to gather more and more data about us and utilize it to enhance their business. It is about time privacy is engineered into each project we build that collects personal, health or protected user information not just to comply with the regulations, but also to protect user’s right to privacy. LINDDUN[1] is a privacy engineering framework that helps model the system, find and manage the threats associated with this system. LINDDUN categorizes the threats into 7 categories such as Linkability, Identifiability, Non-repudiation, Detectability, Disclosure of Information, Unawareness, and Non-compliance. Let’s look at each one of them:
 >
@@ -142,7 +150,7 @@ To aid in going through different cases, there is a model called STRIDE. STRIDE 
 | Escalation of privilege | Authorization            | Grants Unauthorized access     |
 
 > ![NOTE]
-> Tracking Trash Pandas with Data Flow Diagrams Commentary by Ann Wallace
+> **Tracking Trash Pandas with Data Flow Diagrams**, Commentary by Ann Wallace
 >
 > In my experience, a Data Flow Diagram (DFD) is invaluable for threat modeling, providing a detailed view of data management within a system to identify and mitigate security risks. DFDs give a thorough and detailed view of how data is managed within a system, which is critical for identifying, examining, and mitigating potential security risks.
 >

--- a/guidance/background/threat-modeling/understanding-risk.md
+++ b/guidance/background/threat-modeling/understanding-risk.md
@@ -9,7 +9,7 @@ Unfortunately, there really isn’t a solid way to know how likely certain event
 Realistically, you get the most value out of understanding roughly how likely things are 1-in-100 vs 1-in-a-million vs 1-in-a-trillion, etc. versus trying to put an exact number.
 
 > [!NOTE]
-> **The Thousandfold Misconception, Commentary by Justin Cappos**
+> **The Thousandfold Misconception**, Commentary by Justin Cappos
 > I worked with Evan Gilman, Matt Moyer, and Enrico Schiattarella from the SPIFFE / SPIRE team on a threat assessment and as part of it we tried to quantify risk. We each did this independently for aspects of the system; our answers often varied by more than 10. In fact, in one case it varied by more than a factor of 1000! After discussing these differences, we began to better understand ways in which our mental models differed about how the system could be deployed. This was a really useful exercise for us even though I don’t think any of us put a lot of faith that the values we ended up with are close to the real value.
 
 ## Expected Damage
@@ -25,7 +25,7 @@ For example, if something has a 1-in-100 chance of occurring on a specific day, 
 When addressing risks, you can look at how much your protection would cost (in terms of effort, money, etc.) and how this changes the expected damage.  This would be an ideal way to prioritize how to work on things.  So why don’t we do this?  Because the actual values for likelihood and impact aren’t really known in practice. So understanding “that things that are likely and high impact are really bad and need to be addressed” is going to be more useful in practice than the actual formula will be.
 
 > [!NOTE]
-> The Value of Precedence, Commentary by Andrew Martin:
+> **The Value of Precedence**, Commentary by Andrew Martin
 >
 > We have found it helpful to list the remediations and controls from a threat model in precedence order. The recipient of a threat model is likely to be a risk owner such as a CISO or equivalent holder of funds, and the model should inspire them to remediate immediate existential threats, or threats with unacceptable impacts on business functionality, and consider which of the other scoped threats are worth investing in.
 >

--- a/guidance/self-assessment/getting-started-self-assessment.md
+++ b/guidance/self-assessment/getting-started-self-assessment.md
@@ -25,9 +25,9 @@ In this guide, we’re looking to secure an open source project repository. Simi
 
 This guide will walk you through the process of creating your own security self-assessment documentation.
 
-We will be following the recommendations provided by the Cloud Native Computing Foundation to their myriad of open source software projects. The standard of self-assessment is encouraged by TAG Security for sandbox and incubation projects, and it is incentivized by the Cloud Native Security Slam for all CNCF projects to revisit their self-assessment annually.
+We will be following the recommendations provided by the Cloud Native Computing Foundation to their myriad of open source software projects. The standard of self-assessment is required by the CNCF for incubating and graduating projects, and it is incentivized by the Cloud Native Security Slam for all CNCF projects to revisit their self-assessment annually.
 
-Anyone familiar with your project can contribute to the creation of the self-assessment, but it is important that the effort contains a high level of engagement from the project’s leadership—a full review and endorsement at minimum–to ensure that nothing is missed and that any findings are incorporated into the project roadmap.
+Anyone familiar with your project can contribute to the creation of the self-assessment, but it is important that the effort contains a high level of engagement from the project’s leadership—a full review and endorsement at minimum—to ensure that nothing is missed and that any findings are incorporated into the project roadmap.
 
 We will be also creating a self-assessment for our own little open source project—a text execution harness that has been on the back burner for too long, and is getting ready for new contributions. Now is a great time to evaluate the progress and gaps related to security!
 

--- a/templates/self-assessment.md
+++ b/templates/self-assessment.md
@@ -1,6 +1,6 @@
 # Self-assessment
 
-Free-form description of the document's contents from the author's perspective.
+Summarize the document's purpose and status to orient readers.
 
 ## Self-assessment outline
 
@@ -103,7 +103,7 @@ This document serves to provide [project] users with an initial understanding of
 security, and general overview of [project] security practices, both for development of
 [project] as well as security of [project].
 
-This document provides the CNCF TAG-Security with an initial understanding of [project]
+This document provides readers with an initial understanding of [project]
 to assist in a joint-assessment, necessary for projects under incubation.  Taken
 together, this document and the joint-assessment serve as a cornerstone for if and when
 [project] seeks graduation and is preparing for a security audit.


### PR DESCRIPTION
Fixes a number of broken / dangling or missing hyperlinks, and removes a few "TAG Security" references which didn't add value.

Also standardizes `[!NOTE]` usage to `**Bold Title**, attributed Author` format, and adds one missed `[!IMPORTANT]` quote header.
