### PR TITLE
docs: fix broken navigation links and typos

### DIFF
--- a/guidance/background/response/applying-mitigations.md
+++ b/guidance/background/response/applying-mitigations.md
@@ -1,6 +1,6 @@
 # Applying Mitigations
 
-**[< Previous: Applying Mitigations](./applying-mitigations.md)**
+**[< Previous: Detection & Tracing](./detection-and-tracing.md)**
 
 Applying mitigations is usually not as simple as just choosing a set of mitigations and applying them to parts of your system. A common mistake that I see novice system designers make is to focus more on the quantity and type of security mechanisms added than focusing on where and why. You need to reason about the goals your system has and then figure out how to intelligently apply mechanisms and controls to meet those goals.
 

--- a/guidance/background/response/detection-and-tracing.md
+++ b/guidance/background/response/detection-and-tracing.md
@@ -1,6 +1,6 @@
 # Detection & Tracing
 
-**[< Previous: Comprehensive Coverage](./comprehensive-coverage.md)**
+**[< Previous: Comprehensive Coverage](../threat-modeling/comprehensive-coverage.md)**
 
 The core concept of defensive security is to take things that are damaging and either make them less likely or less impactful.
 

--- a/guidance/background/response/recovery-and-prevention.md
+++ b/guidance/background/response/recovery-and-prevention.md
@@ -1,6 +1,6 @@
 # Recovery & Prevention
 
-**[< Previous: Recovery & Prevention](./recovery-and-prevention.md)**
+**[< Previous: Applying Mitigations](./applying-mitigations.md)**
 
 Downstream from detection and tracing is recovery, and then that concept naturally leads us back around to the thought of preventing a breach in the first place.
 

--- a/guidance/background/threat-modeling/attack-graphs-technique.md
+++ b/guidance/background/threat-modeling/attack-graphs-technique.md
@@ -1,10 +1,10 @@
 # Threat Modeling: Attack Graphs Technique
 
-**[< Previous: Goals](../goals.md)**
+**[< Previous: Goals](./goals.md)**
 
 Once you understand the potential attacker(s) and a goal, it is helpful to think through the ways in which they could achieve this.
 
-hile you can just sit and do this in whatever way you want, it is often useful to reason about this by brainstorming using a tool called an Attack Graph. This is also called an Attack Tree, Threat Tree, or Threat Graph in some literature.
+While you can just sit and do this in whatever way you want, it is often useful to reason about this by brainstorming using a tool called an Attack Graph. This is also called an Attack Tree, Threat Tree, or Threat Graph in some literature.
 
 An attack tree has at the top (which is called the root node), the goal of the attacker.
 

--- a/guidance/getting-started.md
+++ b/guidance/getting-started.md
@@ -38,4 +38,4 @@ You, the consumer of this hard work, need to understand how best to benefit from
 
 As with many things in security there is often not one “correct answer”, despite there being infinite wrong answers. If you would like to ask questions or help improve this guidance, please don't hesitate to engage through the designated [community channels](../CONTRIBUTING.md).
 
-**[> Next up: Security Assessements and Audits](./assessments-and-audits.md)**
+**[> Next up: Security Assessments and Audits](./background/assessments-and-audits.md)**

--- a/guidance/self-assessment/development-and-support.md
+++ b/guidance/self-assessment/development-and-support.md
@@ -66,4 +66,4 @@ If your project lacks a comprehensive plan for incident response, then include a
 
 A clear incident response process ensures vulnerabilities are addressed efficiently while minimizing disruption.
 
-**[> Next Up: Security Considerations](./security-considerations.md)**
+**[> Next Up: Appendix](./appendix.md)**


### PR DESCRIPTION
Six navigation links were pointing to wrong paths or to themselves, producing 404s for readers walking through the guide sequentially.